### PR TITLE
Add installer/uninstaller for Global Catalog

### DIFF
--- a/ipaserver/install/gc.py
+++ b/ipaserver/install/gc.py
@@ -70,6 +70,10 @@ def install_check(api, installer):
             logger.debug("Unable to connect to the local instance: %s", e)
             raise RuntimeError("IPA must be running, please run ipactl start")
 
+    # Check that a trust is installed
+    if not api.Command['adtrust_is_enabled']()['result']:
+        raise RuntimeError("AD Trusts are not enabled on this server")
+
 
 def install(api, fstore, installer):
     options = installer

--- a/ipaserver/install/gcinstance.py
+++ b/ipaserver/install/gcinstance.py
@@ -47,8 +47,6 @@ from lib389.idm.ipadomain import IpaDomain
 from lib389.instance.options import General2Base, Slapd2Base
 from lib389.instance.setup import SetupDs
 
-from samba.dcerpc.security import dom_sid
-from samba.ndr import ndr_pack, ndr_unpack, ndr_print
 
 logger = logging.getLogger(__name__)
 
@@ -263,6 +261,9 @@ class GCInstance(service.Service):
         self.disable()
 
     def __setup_sub_dict(self):
+        from samba.dcerpc.security import dom_sid
+        from samba.ndr import ndr_pack, ndr_unpack, ndr_print
+
         server_root = find_server_root()
         trustconfig = api.Command.trustconfig_show()['result']
         domainguid = base64.b64encode(


### PR DESCRIPTION
In order to install:
  /usr/libexec/ipa/gc/ipa-gc-install --gc-password <pwd> -U
- installs the global catalog as a dirsrv instance in
  /etc/dirsrv/slapd-GLOBAL-CATALOG
- the instance has a cn=Directory Manager user with <pwd>
- the instance is listening on 3268 and 3269
- for CA-less installs, specify --gc-cert-file <pkcs12> --gc-pin <pin>

In order to uninstall:
  /usr/libexec/ipa/ipa-gc-install --uninstall -U
- removes the instance

The installation creates an entry
cn=GLOBAL-CATALOG,cn=<hostname>,cn=masters,cn=ipa,cn=etc,<BASEDN>
which means that ipactl start/ipactl stop also starts/stops the GC.