### PR TITLE
Global Catalog improvements

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -450,6 +450,7 @@ Requires(post): python3
 Requires: python3-samba
 Requires: python3-libsss_nss_idmap
 Requires: python3-sss
+Requires: python3-jinja2
 
 # We use alternatives to divert winbind_krb5_locator.so plugin to libkrb5
 # on the installes where server-trust-ad subpackage is installed because
@@ -1106,7 +1107,7 @@ fi
 %license COPYING
 %{python3_sitelib}/ipaserver
 %{python3_sitelib}/ipaserver-*.egg-info
-
+%exclude %{python3_sitelib}/ipaserver/globalcatalog
 
 %files server-common
 %doc README.md Contributors.txt
@@ -1222,6 +1223,7 @@ fi
 %{_sysconfdir}/dbus-1/system.d/oddjob-ipa-trust.conf
 %{_sysconfdir}/oddjobd.conf.d/oddjobd-ipa-trust.conf
 %%attr(755,root,root) %{_libexecdir}/ipa/oddjob/com.redhat.idm.trust-fetch-domains
+%{python3_sitelib}/ipaserver/globalcatalog
 
 # ONLY_CLIENT
 %endif

--- a/install/gc/convert-schema
+++ b/install/gc/convert-schema
@@ -188,11 +188,11 @@ filteredClasses = {
         'adminDescription': 'ad-mailReciipient',
         'governsID': '2.16.840.1.113730.3.8.26.3',
     },
-    'group': {
-        'lDAPDisplayName': 'ad-group',
-        'adminDescription': 'ad-group',
-        'governsID': '2.16.840.1.113730.3.8.26.4',
-    },
+#    'group': {
+#        'lDAPDisplayName': 'ad-group',
+#        'adminDescription': 'ad-group',
+#        'governsID': '2.16.840.1.113730.3.8.26.4',
+#    },
     'organizationalPerson': {
         'lDAPDisplayName': 'ad-organizationalPerson',
         'adminDescription': 'ad-organizationalPerson',

--- a/install/gc/share/base/00-ad-schema-2016.ldif
+++ b/install/gc/share/base/00-ad-schema-2016.ldif
@@ -2633,8 +2633,8 @@ objectClasses: (1.2.840.113556.1.5.157 NAME 'groupPolicyContainer'
     STRUCTURAL
     MAY ( versionNumber $ flags )
     X-ORIGIN 'MS-WSPP')
-objectClasses: (2.16.840.1.113730.3.8.26.4 NAME 'ad-group'
-    DESC 'ad-group'
+objectClasses: (1.2.840.113556.1.5.8 NAME 'group'
+    DESC 'Group'
     SUP ad-top
     STRUCTURAL
     MUST ( groupType )

--- a/ipaserver/dns_data_management.py
+++ b/ipaserver/dns_data_management.py
@@ -50,6 +50,14 @@ IPA_DEFAULT_ADTRUST_SRV_REC = (
     (DNSName('_kerberos._udp.dc._msdcs'), 88),
 )
 
+IPA_DEFAULT_GC_SRV_REC = (
+    # srv record name, port
+    (DNSName('_ldap._tcp.Default-First-Site-Name._sites.gc._msdcs'), 3268),
+    (DNSName('_ldap._tcp.gc._msdcs'), 3268),
+    (DNSName('_gc._tcp.Default-First-Site-Name._sites'), 3268),
+    (DNSName('_gc._tcp'), 3268),
+)
+
 IPA_DEFAULT_NTP_SRV_REC = (
     # srv record name, port
     (DNSName("_ntp._udp"), 123),
@@ -205,6 +213,12 @@ class IPASystemRecords:
                 IPA_DEFAULT_ADTRUST_SRV_REC,
                 weight=server['weight']
             )
+
+        if 'Global Catalog server' in eff_roles:
+            self.__add_srv_records(
+                zone_obj, hostname_abs,
+                IPA_DEFAULT_GC_SRV_REC,
+                weight=server['weight'])
 
         if 'NTP server' in eff_roles:
             self.__add_srv_records(

--- a/ipaserver/globalcatalog/templates/gc_group_template.tmpl
+++ b/ipaserver/globalcatalog/templates/gc_group_template.tmpl
@@ -1,0 +1,18 @@
+dn: CN={{ pkey }},CN=Users,{{ suffix }}
+objectClass: top
+objectClass: ad-top
+objectClass: group
+objectClass: securityprincipal
+cn: {{ pkey }}
+instanceType: 4
+name: {{ pkey }}
+objectGUID:: {{ guid }}
+objectSid:: {{ sid }}
+sAMAccountName:  {{ pkey }}
+sAMAccountType: 268435456
+objectCategory: CN=Group,CN=Schema,CN=Configuration,{{ suffix }}
+ntsecuritydescriptor: D:(A;;RPWPCRCCDCLCLORCWOWDSDDTSW;;;DA)(A;;RPWPCRCCDCLCLORCWOWDSDDTSW;;;SY)(A;;RPLCLORC;;;AU)(A;;RPWPCRCCDCLCLORCWOWDSDDTSW;;;AO)(A;;RPLCLORC;;;PS)(OA;;CR;ab721a55-1e2f-11d0-9819-00aa0040529b;;AU)
+{%- for member in entry['member'] %}
+member: {{ member }}
+{%- endfor %}
+groupType: -2147483646

--- a/ipaserver/globalcatalog/templates/gc_user_template.tmpl
+++ b/ipaserver/globalcatalog/templates/gc_user_template.tmpl
@@ -1,0 +1,48 @@
+{% macro first_val(attr) -%}
+    {{ entry[attr][0] }}
+{%- endmacro %}
+dn: CN={{ first_val('cn') }},CN=Users,{{ suffix }}
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: ad-top
+objectClass: ad-organizationalPerson
+objectClass: user
+objectClass: securityPrincipal
+objectClass: posixAccount
+objectClass: inetUser
+cn: {{ first_val('cn') }}
+sn: {{ first_val('sn') }}
+{%- if entry['givenname'] %}
+givenName: {{ first_val('givenname') }}
+{%- endif %}
+instanceType: 4
+{%- if entry['displayname'] %}
+displayName: {{ entry.single_value['displayname'] }}
+{%- endif %}
+name: {{ first_val('cn') }}
+objectGUID:: {{ guid }}
+userAccountControl: 66048
+primaryGroupID: 513
+objectSid:: {{ sid }}
+sAMAccountName: {{ pkey }}
+sAMAccountType: 805306368
+{%- if entry['krbcanonicalname'] %}
+userPrincipalName: {{ entry.single_value['krbcanonicalname'] }}
+{%- else %}
+userPrincipalName: {{ first_val('krbprincipalname') }}
+{%- endif %}
+objectCategory: CN=Person,CN=Schema,CN=Configuration,{{ suffix }}
+{%- if entry['mail'] %}
+mail: {{ first_val('mail') }}
+{%- endif %}
+uidnumber: {{ first_val('uidnumber') }}
+gidnumber: {{ first_val('gidnumber') }}
+{%- for uid in entry['uid'] %}
+uid: {{ uid }}
+{%- endfor %}
+homeDirectory: {{ first_val('homedirectory') }}
+{%- for group in entry['memberof'] %}
+memberof: {{ group }}
+{%- endfor %}
+nTSecurityDescriptor: D:(A;;RPWPCRCCDCLCLORCWOWDSDDTSW;;;DA)(A;;RPWPCRCCDCLCLORCWOWDSDDTSW;;;SY)(A;;RPLCLORC;;;AU)(OA;;WP;736e4812-af31-11d2-b7df-00805f48caeb;bf967ab8-0de6-11d0-a285-00aa003049e2;CO)(A;;SD;;;CO)

--- a/ipaserver/globalcatalog/transfo.py
+++ b/ipaserver/globalcatalog/transfo.py
@@ -1,0 +1,124 @@
+import base64
+from jinja2 import Environment, PackageLoader
+from samba.dcerpc import security
+from samba.ndr import ndr_pack
+import uuid
+
+from ipalib import api
+from ipapython.dn import DN
+
+
+def transform_sid(sid):
+    """Transforms a SID from a string format to an AD-compatible format
+
+    For instance input: (string) S-1-5-21-290024825-4011531429-1633689518-500
+    output: (string) AQUAAAAAAAUVAAAAeW1JEaUcG++uH2Bh7QMAAA==
+    """
+    return base64.b64encode(ndr_pack(security.dom_sid(sid))).decode('utf-8')
+
+
+def transform_gid(uniqueid):
+    """Transforms an id from a string format to an AD-compatible format
+
+    For instance input: (string) 7d976a62-0703-11ea-89b6-001a4a2312ca
+    output (string): fZdqYgcDEeqJtgAaSiMSyg==
+    """
+    return base64.b64encode(uuid.UUID(uniqueid).bytes).decode('utf-8')
+
+
+def rename_group_members(api, group, conn):
+    """Fix the member attribute of a group entry
+
+    In IdM the users are below cn=users,cn=accounts,$suffix
+    and they have a dn: uid=%uid%
+    but in the Global Catalog they are in CN=Users,$suffix
+    and they have a dn: Cn=%cn%
+    """
+    users_dn = DN(api.env.container_user, api.env.basedn)
+    groups_dn = DN(api.env.container_group, api.env.basedn)
+
+    new_member_attr = []
+    for memberDN in group.get('member', []):
+        if memberDN.find(users_dn) == 1:
+            # The member value is right below the user container
+            # Need to find the CN single_value
+            user = conn.get_entry(
+                memberDN, ["cn"], time_limit=0, size_limit=-1)
+            user_cn = user.single_value['cn']
+            new_member_attr.append(DN(
+                'cn={}'.format(user_cn), 'cn=users', api.env.basedn))
+            continue
+        if memberDN.find(groups_dn) == 1:
+            # The member value is right below the group container
+            new_member_attr.append(DN(
+                memberDN[0], 'cn=users', api.env.basedn))
+
+    group['member'] = new_member_attr
+
+
+def rename_groups(api, user):
+    """Fix the memberof attribute of a user get_entry
+
+    In IdM the groups are below cn=groups,cn=accounts,$suffix but in
+    the Global Catalog they are in CN=Users,$suffix
+    """
+    groups_dn = DN(api.env.container_group, api.env.basedn)
+    new_memberof_attr = []
+    for groupDN in user.get('memberof', []):
+        if groupDN.find(groups_dn) == 1:
+            # The memberof value is right below the group container
+            # rename and append
+            new_memberof_attr.append(
+                DN(groupDN[0], 'cn=users', api.env.basedn))
+            continue
+        # The memberof is not in the group container, keep as-is
+        new_memberof_attr.append(groupDN)
+
+    user['memberof'] = new_memberof_attr
+
+
+class GCTransformer:
+    def __init__(self, api, conn):
+        loader = PackageLoader('ipaserver', 'globalcatalog/templates')
+        jinja_env = Environment(loader=loader)
+        self.user_template = jinja_env.get_template('gc_user_template.tmpl')
+        self.group_template = jinja_env.get_template('gc_group_template.tmpl')
+        self.api = api
+        self.ldap_conn = conn
+
+    def create_ldif_user(self, entry):
+        """Creates a LDIF allowing to add the entry
+
+        entry: the input user entry
+        template: the jinja template to apply
+        """
+        # the uid value is multivalued, extract the right one as primary key
+        # (i.e. the one from the DN)
+        pkey = entry.dn[0][0].value
+        sid = transform_sid(entry.single_value['ipantsecurityidentifier'])
+        guid = transform_gid(entry.single_value['ipauniqueid'])
+        rename_groups(api, entry)
+        ldif_add = self.user_template.render(
+            entry=entry, pkey=pkey, sid=sid, guid=guid,
+            suffix=api.env.basedn)
+        return ldif_add
+
+    def create_ldif_group(self, entry):
+        """Creates a LDIF allowing to add the group entry
+
+        entry: the input group entry
+        template: the jinja template to apply
+        """
+        # the cn value is multivalued, extract the right one as primary key
+        # (i.e. the one from the DN)
+        pkey = entry.dn[0][0].value
+        try:
+            sid = transform_sid(entry.single_value['ipantsecurityidentifier'])
+        except KeyError:
+            sid = None
+        guid = transform_gid(entry.single_value['ipauniqueid'])
+        rename_group_members(self.api, entry, conn=self.ldap_conn)
+        ldif_add = self.group_template.render(
+            entry=entry, pkey=pkey, guid=guid,
+            sid=sid, suffix=api.env.basedn)
+        return ldif_add

--- a/ipaserver/install/gc.py
+++ b/ipaserver/install/gc.py
@@ -70,6 +70,10 @@ def install_check(api, installer):
             logger.debug("Unable to connect to the local instance: %s", e)
             raise RuntimeError("IPA must be running, please run ipactl start")
 
+    # Check that a trust is installed
+    if not api.Command['adtrust_is_enabled']()['result']:
+        raise RuntimeError("AD Trusts are not enabled on this server")
+
 
 def install(api, fstore, installer):
     options = installer

--- a/ipaserver/install/gc.py
+++ b/ipaserver/install/gc.py
@@ -107,6 +107,10 @@ def install(api, fstore, installer):
     # gc.change_admin_password(admin_password)
 
     service.sync_services_state(api.env.host)
+    # After this point the Global Catalog is seen as enabled
+    # Add the DNS SRV entries for GC
+    api.Command.dns_update_system_records()
+
     print("======================================="
           "=======================================")
     print("Setup complete")

--- a/ipaserver/install/gcinstance.py
+++ b/ipaserver/install/gcinstance.py
@@ -135,20 +135,21 @@ class GCInstance(service.Service):
                                          self.service_prefix)):
             return None
 
-        return unicode(
-            Principal(
-                (self.service_prefix, self.fqdn, self.domain), realm=self.realm))
+        return unicode(Principal(
+            (self.service_prefix, self.fqdn, self.domain), realm=self.realm))
 
     def __common_setup(self):
         self.step("creating global catalog instance", self.__create_instance)
         self.step("configure autobind for root", self.__root_autobind)
-        self.step("Enable objectGUID generator", self.__add_objectguid_generator)
+        self.step("Enable objectGUID generator",
+                  self.__add_objectguid_generator)
         self.step("stopping global catalog", self.__stop_instance)
         self.step("updating configuration in dse.ldif", self.__update_dse_ldif)
         self.step("starting global catalog", self.__start_instance)
         self.step("adding default schema", self.__add_default_schemas)
         self.step("creating indices", self.__create_indices)
-        self.step("add global catalog service principal aliases", self.__add_service_alias)
+        self.step("add global catalog service principal aliases",
+                  self.__add_service_alias)
         self.step("configure dirsrv ccache and keytab",
                   self.configure_systemd_ipa_env)
         self.step("enabling SASL mapping fallback",
@@ -250,12 +251,12 @@ class GCInstance(service.Service):
             objectclass=["top", "nsSaslMapping"],
             cn=["Read-Only Principal"],
             nsSaslMapRegexString=[r'^[^:]+$'],
-            nsSaslMapBaseDNTemplate=[DN(('cn', 'configuration')) + self.suffix],
+            nsSaslMapBaseDNTemplate=[DN(('cn', 'configuration')) +
+                                     self.suffix],
             nsSaslMapFilterTemplate=['(uid=read-only-principal)'],
             nsSaslMapPriority=['10'],
         )
         self.conn.add_entry(entry)
-
 
     def __enable(self):
         self.backup_state("enabled", self.is_enabled())
@@ -271,10 +272,10 @@ class GCInstance(service.Service):
         trustconfig = api.Command.trustconfig_show()['result']
         domainguid = base64.b64encode(
             uuid.UUID(trustconfig['ipantdomainguid'][0]).bytes
-            ).decode('utf-8')
+        ).decode('utf-8')
         domainsid = base64.b64encode(ndr_pack(
             security.dom_sid(trustconfig['ipantsecurityidentifier'][0]))
-            ).decode('utf-8')
+        ).decode('utf-8')
 
         self.sub_dict = dict(
             FQDN=self.fqdn,

--- a/ipaserver/install/gcinstance.py
+++ b/ipaserver/install/gcinstance.py
@@ -47,8 +47,6 @@ from lib389.idm.ipadomain import IpaDomain
 from lib389.instance.options import General2Base, Slapd2Base
 from lib389.instance.setup import SetupDs
 
-from samba.dcerpc.security import dom_sid
-from samba.ndr import ndr_pack, ndr_unpack, ndr_print
 
 logger = logging.getLogger(__name__)
 
@@ -263,13 +261,16 @@ class GCInstance(service.Service):
         self.disable()
 
     def __setup_sub_dict(self):
+        from samba.dcerpc import security
+        from samba.ndr import ndr_pack
+
         server_root = find_server_root()
         trustconfig = api.Command.trustconfig_show()['result']
         domainguid = base64.b64encode(
             uuid.UUID(trustconfig['ipantdomainguid'][0]).bytes
             ).decode('utf-8')
         domainsid = base64.b64encode(ndr_pack(
-            dom_sid(trustconfig['ipantsecurityidentifier'][0]))
+            security.dom_sid(trustconfig['ipantsecurityidentifier'][0]))
             ).decode('utf-8')
 
         self.sub_dict = dict(

--- a/ipaserver/install/ipa_gc_install.py
+++ b/ipaserver/install/ipa_gc_install.py
@@ -47,6 +47,11 @@ class GCInstallInterface(Installable,
         cli_metavar='PIN',
     )
 
+    populate = knob(
+        None,
+        description="Fill the global catalog with IdM user and group entries",
+    )
+
 
 class GCServerInstall(GCInstallInterface):
     @step()

--- a/ipaserver/install/upgradeinstance.py
+++ b/ipaserver/install/upgradeinstance.py
@@ -78,7 +78,8 @@ class IPAUpgrade(service.Service):
     listeners and updating over ldapi. This way we know the server is
     quiet.
     """
-    def __init__(self, realm_name, files=[], schema_files=[], updates_dir=None):
+    def __init__(self, realm_name, files=[], schema_files=[],
+                 updates_dir=None):
         """
         realm_name: kerberos realm name, used to determine DS instance dir
         files: list of update files to process. If none use UPDATEDIR

--- a/ipaserver/servroles.py
+++ b/ipaserver/servroles.py
@@ -627,6 +627,11 @@ role_instances = (
         u"kra_server_server",
         u"KRA server",
         component_services=['KRA']
+    ),
+    ServiceBasedRole(
+        u"gc_server_server",
+        u"Global Catalog server",
+        component_services=['GLOBAL-CATALOG']
     )
 )
 

--- a/ipaserver/setup.py
+++ b/ipaserver/setup.py
@@ -43,7 +43,13 @@ if __name__ == '__main__':
             'ipaserver.install',
             'ipaserver.install.plugins',
             'ipaserver.install.server',
+            'ipaserver.globalcatalog',
         ],
+        package_data={
+            "ipaserver": [
+                "globalcatalog/templates/*.tmpl",
+            ]
+        },
         install_requires=[
             "cryptography",
             "custodia",
@@ -79,5 +85,6 @@ if __name__ == '__main__':
             "hbactest": ["pyhbac"],
             "install": ["SSSDConfig"],
             "trust": ["pysss_murmur", "pysss_nss_idmap"],
+            "globalcatalog": ["jinja2"]
         }
     )


### PR DESCRIPTION
### ipa-gc-install fixes
- make ipa-server-install work even if samba-client is not installed
currently ipa-server-install calls gc code to check if it needs to
be uninstalled, and it creates a dependency on samba.
Move the import so that there is no dependency on installation.
- make ipa-gc-install check that ad trust is installed

### ipa-gc-setup: create DNS records for gc
At the end of the global catalog install, update the DNS records
with SRV records for the global catalog:
_ldap._tcp.Default-First-Site-Name._sites.gc._msdcs
_ldap._tcp.gc._msdcs
_gc._tcp.Default-First-Site-Name._sites
_gc._tcp

### global catalog: fix codestyle

### Global Catalog: no need to filter the 'group' objectclass

### globalcatalog: add transformations library

### Global Catalog: add populate option to ipa-gc-install
At the end of the global catalog install, the --populate option
allows to copy the users and groups from IdM to the GC.

