### PR TITLE
GC: upgrade + support entries without ipantsecurityidentifier

### DIFF
--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -278,6 +278,11 @@ LDAP_GENERALIZED_TIME_FORMAT = "%Y%m%d%H%M%SZ"
 IPA_ANCHOR_PREFIX = ':IPA:'
 SID_ANCHOR_PREFIX = ':SID:'
 
+# When an entry does not contain ipantsecurityidentifier (for instance a
+# non posix group), IPA will generate a special SID using the following
+# prefix, based on the entry ipauniqueid
+IPA_SID_FAMILY_PREFIX = 'S-1-738065-'
+
 # domains levels
 DOMAIN_LEVEL_0 = 0  # compat
 DOMAIN_LEVEL_1 = 1  # replica promotion, topology plugin

--- a/ipalib/constants.py
+++ b/ipalib/constants.py
@@ -348,3 +348,9 @@ SOFTHSM_DNSSEC_TOKEN_LABEL = u'ipaDNSSEC'
 # Apache's mod_ssl SSLVerifyDepth value (Maximum depth of CA
 # Certificates in Client Certificate verification)
 MOD_SSL_VERIFY_DEPTH = '5'
+
+GC_SERVER_ID = "GLOBAL-CATALOG"
+GC_SERVICE_NAME = "globalcatalog"
+GC_REALM_NAME = "GLOBAL.CATALOG"
+GC_PORT = 3268
+GC_SECURE_PORT = 3269

--- a/ipaplatform/base/paths.py
+++ b/ipaplatform/base/paths.py
@@ -267,6 +267,7 @@ class BasePathNamespace:
     SCHEMA_COMPAT_POST_ULDIF = "/usr/share/ipa/schema_compat_post.uldif"
     IPA_JS_PLUGINS_DIR = "/usr/share/ipa/ui/js/plugins"
     UPDATES_DIR = "/usr/share/ipa/updates/"
+    GC_UPDATES_DIR = "/usr/share/ipa/gc/updates"
     DICT_WORDS = "/usr/share/dict/words"
     VAR_KERBEROS_KRB5KDC_DIR = "/var/kerberos/krb5kdc/"
     VAR_KRB5KDC_K5_REALM = "/var/kerberos/krb5kdc/.k5."

--- a/ipapython/ipaldap.py
+++ b/ipapython/ipaldap.py
@@ -103,6 +103,12 @@ def realm_to_ldapi_uri(realm_name):
     return 'ldapi://' + ldapurl.ldapUrlEscape(socketname)
 
 
+def serverid_to_ldapi_uri(serverid):
+    """Get ldapi:// URI to DS Unix socket based on its instance name """
+    socketname = paths.SLAPD_INSTANCE_SOCKET_TEMPLATE % (serverid,)
+    return 'ldapi://' + ldapurl.ldapUrlEscape(socketname)
+
+
 def ldap_initialize(uri, cacertfile=None):
     """Wrapper around ldap.initialize()
 

--- a/ipaserver/install/gc.py
+++ b/ipaserver/install/gc.py
@@ -113,7 +113,8 @@ def install(api, fstore, installer):
                            subject_base=subject_base,
                            ca_subject=ca_subject,
                            populate=options.populate)
-    # gc.change_admin_password(admin_password)
+
+    gc.apply_updates()
 
     service.sync_services_state(api.env.host)
     # After this point the Global Catalog is seen as enabled

--- a/ipaserver/install/gcinstance.py
+++ b/ipaserver/install/gcinstance.py
@@ -63,11 +63,6 @@ GC_SCHEMA_FILES = ("00-ad-schema-2016.ldif",)
 
 ALL_SCHEMA_FILES = GC_SCHEMA_FILES
 
-GC_SERVER_ID = "GLOBAL-CATALOG"
-GC_SERVICE_NAME = "globalcatalog"
-GC_PORT = 3268
-GC_SECURE_PORT = 3269
-
 
 def check_ports():
     """
@@ -77,8 +72,8 @@ def check_ports():
     secure port 3269. True means that the port is free, False means that the
     port is taken.
     """
-    gc_unsecure = not ipautil.host_port_open(None, GC_PORT)
-    gc_secure = not ipautil.host_port_open(None, GC_SECURE_PORT)
+    gc_unsecure = not ipautil.host_port_open(None, constants.GC_PORT)
+    gc_secure = not ipautil.host_port_open(None, constants.GC_SECURE_PORT)
     return (gc_unsecure, gc_secure)
 
 
@@ -88,7 +83,7 @@ def is_gc_configured():
     is already configured.
     """
     sstore = sysrestore.StateFile(paths.SYSRESTORE)
-    return sstore.has_state(GC_SERVICE_NAME)
+    return sstore.has_state(constants.GC_SERVICE_NAME)
 
 
 class GCInstance(service.Service):
@@ -101,7 +96,7 @@ class GCInstance(service.Service):
         config_ldif=None,
     ):
         super(GCInstance, self).__init__(
-            GC_SERVICE_NAME,
+            constants.GC_SERVICE_NAME,
             service_desc="global catalog server",
             fstore=fstore,
             service_prefix=u"ldap",
@@ -126,7 +121,7 @@ class GCInstance(service.Service):
             self.__setup_sub_dict()
         else:
             self.suffix = DN()
-        self.serverid = GC_SERVER_ID
+        self.serverid = constants.GC_SERVER_ID
         self.conn = None
 
     subject_base = ipautil.dn_attribute_property("_subject_base")
@@ -175,7 +170,7 @@ class GCInstance(service.Service):
         self.realm = realm_name.upper()
         self.suffix = ipautil.realm_to_suffix(self.realm)
         self.fqdn = fqdn
-        self.ldap_uri = ipaldap.get_ldap_uri(realm="GLOBAL.CATALOG",
+        self.ldap_uri = ipaldap.get_ldap_uri(realm=constants.GC_REALM_NAME,
                                              protocol='ldapi')
         self.dm_password = dm_password
         self.domain = domain_name
@@ -324,8 +319,8 @@ class GCInstance(service.Service):
         slapd_options = Slapd2Base(logger)
         slapd_options.set('instance_name', self.serverid)
         slapd_options.set('root_password', self.dm_password)
-        slapd_options.set('port', GC_PORT)
-        slapd_options.set('secure_port', GC_SECURE_PORT)
+        slapd_options.set('port', constants.GC_PORT)
+        slapd_options.set('secure_port', constants.GC_SECURE_PORT)
         slapd_options.verify()
         slapd = slapd_options.collect()
 
@@ -432,7 +427,7 @@ class GCInstance(service.Service):
             self.conn = None
         super(GCInstance, self).stop(*args, **kwargs)
 
-    def restart(self, instance=GC_SERVER_ID):
+    def restart(self, instance=constants.GC_SERVER_ID):
         if self.conn:
             self.conn.close()
             self.conn = None
@@ -693,7 +688,7 @@ class GCInstance(service.Service):
         conn.unbind()
 
         # check for open secure port GC_SECURE_PORT from now on
-        self.open_ports.append(GC_SECURE_PORT)
+        self.open_ports.append(constants.GC_SECURE_PORT)
 
     def __import_ca_certs(self):
         dirname = config_dirname(self.serverid)
@@ -846,7 +841,7 @@ class GCInstance(service.Service):
             dsdb.untrack_server_cert(self.nickname)
 
     def __root_autobind(self):
-        ldap_uri = ipaldap.get_ldap_uri(self.fqdn, port=GC_PORT)
+        ldap_uri = ipaldap.get_ldap_uri(self.fqdn, port=constants.GC_PORT)
         self._ldap_mod(
             "root-autobind.ldif",
             ldap_uri=ldap_uri,

--- a/ipaserver/install/ldapupdate.py
+++ b/ipaserver/install/ldapupdate.py
@@ -150,7 +150,7 @@ class LDAPUpdate:
     )
 
     def __init__(self, dm_password=None, sub_dict={},
-                 online=True, ldapi=False):
+                 online=True, ldapi=False, serverid=None):
         '''
         :parameters:
             dm_password
@@ -273,9 +273,13 @@ class LDAPUpdate:
         self.ldapi = ldapi
         self.pw_name = pwd.getpwuid(os.geteuid()).pw_name
         self.realm = None
+        if serverid is None:
+            self.serverid = ipaldap.realm_to_serverid(api.env.realm)
+        else:
+            self.serverid = serverid
         self.socket_name = (
             paths.SLAPD_INSTANCE_SOCKET_TEMPLATE %
-            api.env.realm.replace('.', '-')
+            self.serverid
         )
         suffix = None
 
@@ -285,7 +289,10 @@ class LDAPUpdate:
             self.realm = api.env.realm
             suffix = ipautil.realm_to_suffix(self.realm) if self.realm else None
 
-        self.ldapuri = ipaldap.realm_to_ldapi_uri(self.realm)
+        if serverid:
+            self.ldapuri = ipaldap.serverid_to_ldapi_uri(serverid)
+        else:
+            self.ldapuri = ipaldap.realm_to_ldapi_uri(self.realm)
         if suffix is not None:
             assert isinstance(suffix, DN)
 

--- a/ipaserver/install/server/upgrade.py
+++ b/ipaserver/install/server/upgrade.py
@@ -39,6 +39,7 @@ from ipaplatform.paths import paths
 from ipaserver import servroles
 from ipaserver.install import installutils
 from ipaserver.install import dsinstance
+from ipaserver.install import gcinstance
 from ipaserver.install import httpinstance
 from ipaserver.install import bindinstance
 from ipaserver.install import service
@@ -355,6 +356,15 @@ def upgrade_adtrust_config():
                 logger.warning("Error updating Samba registry: %s", e)
         else:
             logger.warning("Error updating Samba registry: %s", e)
+
+
+def upgrade_global_catalog(fstore):
+    logger.info('[Upgrading Global Catalog]')
+
+    if not gcinstance.is_gc_configured():
+        logger.info('Global Catalog is not configured')
+        return
+    gcinstance.GCInstance(fstore=fstore).apply_updates()
 
 
 def ca_configure_profiles_acl(ca):
@@ -2067,6 +2077,7 @@ def upgrade_configuration():
     cleanup_adtrust(fstore)
     cleanup_dogtag()
     upgrade_adtrust_config()
+    upgrade_global_catalog(fstore)
 
     bind = bindinstance.BindInstance(fstore)
     if bind.is_configured() and not bind.is_running():

--- a/ipaserver/install/upgradeinstance.py
+++ b/ipaserver/install/upgradeinstance.py
@@ -27,6 +27,7 @@ import random
 import traceback
 
 from ipalib import api
+from ipalib.constants import GC_SERVICE_NAME, GC_REALM_NAME, GC_SERVER_ID
 from ipaplatform.paths import paths
 from ipaplatform import services
 from ipapython import ipaldap
@@ -90,7 +91,22 @@ class IPAUpgrade(service.Service):
         for _i in range(8):
             h = "%02x" % rand.randint(0,255)
             ext += h
-        super(IPAUpgrade, self).__init__("dirsrv", realm_name=realm_name)
+        # When IPAUpgrade is called for the Global Catalog, there is a special
+        # handling: the init is is done with realm=GLOBAL.CATALOG but
+        # this is only a convention to differentiate between GC and primary DS.
+        # The following values need to be adapted:
+        #              |                   Primary DS | Global Catalog
+        # -------------+------------------------------+-------------------
+        # Service Name |                       dirsrv | globalcatalog
+        # Service id   | from realm, replace . with - | GLOBAL-CATALOG
+        # Suffix       |                   from realm | same suffix as ds
+        # Realm        |           from api.env.realm | from api.env.realm
+        # At the end of this method the realm is forced to api.env.realm
+        if realm_name == GC_REALM_NAME:
+            service_name = GC_SERVICE_NAME
+        else:
+            service_name = "dirsrv"
+        super(IPAUpgrade, self).__init__(service_name, realm_name=realm_name)
         serverid = ipaldap.realm_to_serverid(realm_name)
         self.filename = '%s/%s' % (paths.ETC_DIRSRV_SLAPD_INSTANCE_TEMPLATE % serverid, DSE)
         self.savefilename = '%s/%s.ipa.%s' % (paths.ETC_DIRSRV_SLAPD_INSTANCE_TEMPLATE % serverid, DSE, ext)
@@ -107,16 +123,18 @@ class IPAUpgrade(service.Service):
     def __start(self):
         srv = services.service(self.service_name, api)
         srv.start(self.serverid, ldapi=True)
-        api.Backend.ldap2.connect()
+        if self.serverid != GC_SERVER_ID:
+            api.Backend.ldap2.connect()
 
     def __stop_instance(self):
         """Stop only the main DS instance"""
-        if api.Backend.ldap2.isconnected():
+        if self.serverid != GC_SERVER_ID and api.Backend.ldap2.isconnected():
             api.Backend.ldap2.disconnect()
         super(IPAUpgrade, self).stop(self.serverid)
 
     def create_instance(self):
-        ds_running = super(IPAUpgrade, self).is_running()
+        ds_running = super(IPAUpgrade, self).is_running(
+            instance_name=self.serverid)
         if ds_running:
             self.step("stopping directory server", self.__stop_instance)
         self.step("saving configuration", self.__save_config)
@@ -276,7 +294,8 @@ class IPAUpgrade(service.Service):
 
     def __upgrade(self):
         try:
-            ld = ldapupdate.LDAPUpdate(dm_password='', ldapi=True)
+            ld = ldapupdate.LDAPUpdate(dm_password='', ldapi=True,
+                                       serverid=self.serverid)
             if len(self.files) == 0:
                 self.files = ld.get_all_files(self.updates_dir)
             self.modified = (ld.update(self.files) or self.modified)


### PR DESCRIPTION
### Global catalog: handle entries without ipantsecurityidentifier

The transformation library builds a SID for each user/group from the
value of ipantsecurityidentifier, but some entries don't contain this
attribute (for instance the non-posix groups).

For these entries, the SID is created from the ipauniqueid and a special
SID prefix S-1-738065- (ASCII codes of IPA concatenated) .

### Global Catalog: support upgrade

The upgrade is called at the end of ipa-gc-setup and also during ipa-server-upgrade.