### PR TITLE
AJP: add trigger to upgrade FreeIPA on tomcat 9.0.31+ upgrade

### DIFF
--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1109,10 +1109,6 @@ fi
 %{_sbindir}/ipa-cert-fix
 %{_libexecdir}/certmonger/dogtag-ipa-ca-renew-agent-submit
 %{_libexecdir}/certmonger/ipa-server-guard
-%{_libexecdir}/ipa/custodia/ipa-custodia-dmldap
-%{_libexecdir}/ipa/custodia/ipa-custodia-pki-tomcat
-%{_libexecdir}/ipa/custodia/ipa-custodia-pki-tomcat-wrapped
-%{_libexecdir}/ipa/custodia/ipa-custodia-ra-agent
 %dir %{_libexecdir}/ipa
 %{_libexecdir}/ipa/ipa-custodia
 %{_libexecdir}/ipa/ipa-custodia-check
@@ -1121,6 +1117,11 @@ fi
 %{_libexecdir}/ipa/ipa-pki-retrieve-key
 %{_libexecdir}/ipa/ipa-pki-wait-running
 %{_libexecdir}/ipa/ipa-otpd
+%dir %{_libexecdir}/ipa/custodia
+%attr(755,root,root) %{_libexecdir}/ipa/custodia/ipa-custodia-dmldap
+%attr(755,root,root) %{_libexecdir}/ipa/custodia/ipa-custodia-pki-tomcat
+%attr(755,root,root) %{_libexecdir}/ipa/custodia/ipa-custodia-pki-tomcat-wrapped
+%attr(755,root,root) %{_libexecdir}/ipa/custodia/ipa-custodia-ra-agent
 %dir %{_libexecdir}/ipa/oddjob
 %attr(0755,root,root) %{_libexecdir}/ipa/oddjob/org.freeipa.server.conncheck
 %attr(0755,root,root) %{_libexecdir}/ipa/oddjob/org.freeipa.server.trust-enable-agent

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -1081,6 +1081,24 @@ fi
 
 %if ! %{ONLY_CLIENT}
 
+%triggerin server -- tomcat >= 1:9.0.31
+%{__python3} -c "import sys; from ipaserver.install import installutils; sys.exit(0 if installutils.is_ipa_configured() else 1);" > /dev/null 2>&1
+if [  $? -eq 0 ]; then
+    # Run upgrade code if new tomcat is installed but AJP connector is not
+    # encrypted yet or server.xml uses old requiredSecret attribute. Use
+    # systemd-run to create an isolated environment to detach from the security
+    # context used by the rpm transaction
+    if [ -f /etc/httpd/conf.d/ipa-pki-proxy.conf ] ; then
+        convert_httpd_conf=$(grep -c secret= /etc/httpd/conf.d/ipa-pki-proxy.conf)
+        convert_server_xml=$(egrep 'Connector.*port.*8009.*protocol.*AJP' /etc/pki/pki-tomcat/server.xml | grep -c requiredSecret)
+        [ $convert_httpd_conf -eq 0 -o $convert_server_xml -ne 0 ] && \
+            /usr/bin/systemd-run \
+                --description "Upgrade FreeIPA to secure AJP connector for tomcat 9.0.31+" \
+                --unit=ipa-server-upgrade-ajp-connector --wait \
+                %{__python3} -c "from ipaserver.install.server.upgrade import update_and_secure_ajp_connector; update_and_secure_ajp_connector();"
+    fi
+fi
+
 %files server
 %doc README.md Contributors.txt
 %license COPYING

--- a/ipaserver/install/ipa_restore.py
+++ b/ipaserver/install/ipa_restore.py
@@ -474,6 +474,14 @@ class Restore(admintool.AdminTool):
                 http.remove_httpd_ccaches()
                 # have the daemons pick up their restored configs
                 tasks.systemd_daemon_reload()
+                # Restart IPA a final time.
+                # Starting then restarting is necessary to make sure some
+                # daemons like httpd are restarted
+                # (https://pagure.io/freeipa/issue/8226).
+                logger.info('Restarting IPA services')
+                result = run([paths.IPACTL, 'restart'], raiseonerr=False)
+                if result.returncode != 0:
+                    logger.error('Restarting IPA failed: %s', result.error_log)
         finally:
             try:
                 os.chdir(cwd)


### PR DESCRIPTION
Add an installation trigger to force FreeIPA upgrade when tomact 9.0.31
or later is installed. A tomcat package upgrade might happen
independently of FreeIPA upgrade and thus would require to upgrade
FreeIPA configuration before IPA itself could be restarted. The upgrade
code in `ipactl` will not be able to tell the difference because no
changes are there for FreeIPA version. Instead, if upgrade wasn't done
yet (ipa-pki-proxy.conf does not contain secret=... options), force
ipa-server-upgrade run.

We cannot simply run ipa-server-upgrade in the trigger itself because
that would make it inherit a security context used by rpm. Instead,
start a transient systemd service which will isolate ipa-server-upgrade
in a clean and detached execution environment with the service manager
as its parent process.

Related: https://pagure.io/freeipa/issue/8221
Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>