### PR TITLE
GC installation: generate a random password for GC's directory manager

### DIFF
--- a/install/tools/ipa-adtrust-install.in
+++ b/install/tools/ipa-adtrust-install.in
@@ -93,9 +93,6 @@ def parse_options():
                       help="Enable support for trusted domains for old "
                            "clients")
     gc_group = OptionGroup(parser, "global catalog options")
-    gc_group.add_option("--gc-password", sensitive=True, dest="gc_password",
-                        help="Directory Manager password for the Global "
-                             "Catalog")
     gc_group.add_option("--gc-cert-file", dest="gc_cert_files",
                         action="append", metavar="FILE",
                         default=[],

--- a/install/tools/man/ipa-adtrust-install.1
+++ b/install/tools/man/ipa-adtrust-install.1
@@ -144,9 +144,6 @@ path.
 
 .SH "GLOBAL CATALOG OPTIONS"
 .TP
-\fB\-\-gc\-password\fR=\fIGC_PASSWORD\fR
-Directory Manager password for the Global Catalog.
-.TP
 \fB\-\-gc\-cert\-file\fR=\fIFILE\fR
 File containing the Global Catalog SSL certificate and private key. The files
 are accepted in PEM and DER  certificate, PKCS#7 certificate chain, PKCS#8 and

--- a/install/tools/man/ipa-server-install.1
+++ b/install/tools/man/ipa-server-install.1
@@ -280,9 +280,6 @@ path.
 The Global Catalog options are available only when AD Trust installation is selected.
 
 .TP
-\fB\-\-gc\-password\fR=\fIGC_PASSWORD\fR
-Directory Manager password for the Global Catalog.
-.TP
 \fB\-\-gc\-cert\-file\fR=\fIFILE\fR
 File containing the Global Catalog SSL certificate and private key. The files
 are accepted in PEM and DER  certificate, PKCS#7 certificate chain, PKCS#8 and

--- a/ipaserver/install/server/__init__.py
+++ b/ipaserver/install/server/__init__.py
@@ -437,11 +437,6 @@ class ServerInstallInterface(ServerCertificateInstallInterface,
                     "You cannot specify a --no-msdcs option without the "
                     "--setup-adtrust option")
 
-            if self.gc_password:
-                raise RuntimeError(
-                    "You cannot specify a --gc-password option without the "
-                    "--setup-adtrust option")
-
             if self.gc_cert_files:
                 raise RuntimeError(
                     "You cannot specify a --gc-cert-file option without the "


### PR DESCRIPTION
The password is not needed outside of the installation
as ldapi connection is used.