### PR TITLE
GC: fixes for CA less installs

### DIFF
--- a/install/tools/ipa-adtrust-install.in
+++ b/install/tools/ipa-adtrust-install.in
@@ -223,9 +223,9 @@ def main():
             "Unrecognized error during check of admin rights: %s" % e)
 
     adtrust.install_check(True, options, api)
-    gc.install_check(api, options)
+    gc.install_check(True, api, options)
     adtrust.install(True, options, fstore, api)
-    gc.install(api, fstore, options)
+    gc.install(True, api, fstore, options)
 
     # Enable configured services and update DNS SRV records
     service.sync_services_state(api.env.host)

--- a/install/tools/man/ipa-server-certinstall.1
+++ b/install/tools/man/ipa-server-certinstall.1
@@ -22,13 +22,13 @@ ipa\-server\-certinstall \- Install new SSL server certificates
 .SH "SYNOPSIS"
 ipa\-server\-certinstall [\fIOPTION\fR]... FILE...
 .SH "DESCRIPTION"
-Replace the current Directory server SSL certificate, Apache server SSL certificate and/or Kerberos KDC certificate with the certificate in the specified files. The files are accepted in PEM and DER certificate, PKCS#7 certificate chain, PKCS#8 and raw private key and PKCS#12 formats.
+Replace the current Directory server SSL certificate, Apache server SSL certificate, Global Catalog certificate and/or Kerberos KDC certificate with the certificate in the specified files. The files are accepted in PEM and DER certificate, PKCS#7 certificate chain, PKCS#8 and raw private key and PKCS#12 formats.
 
 PKCS#12 is a file format used to safely transport SSL certificates and public/private keypairs.
 
 They may be generated and managed using the NSS pk12util command or the OpenSSL pkcs12 command.
 
-The service(s) are not automatically restarted. In order to use the newly installed certificate(s) you will need to manually restart the Directory, Apache and/or Krb5kdc servers.
+The service(s) are not automatically restarted. In order to use the newly installed certificate(s) you will need to manually restart the Directory, Apache, Global Catalog and/or Krb5kdc servers.
 
 .SH "OPTIONS"
 .TP 
@@ -40,6 +40,9 @@ Install the certificate in the Apache Web Server
 .TP
 \fB\-k\fR, \fB\-\-kdc\fR
 Install the certificate in the Kerberos KDC
+.TP
+\fB\-g\fR, \fB\-\-gcsrv\fR
+Install the certificate on the Global Catalog
 .TP
 \fB\-\-pin\fR=\fIPIN\fR
 The password to unlock the private key

--- a/ipaclient/install/ipa_certupdate.py
+++ b/ipaclient/install/ipa_certupdate.py
@@ -33,7 +33,7 @@ from ipaplatform import services
 from ipaplatform.paths import paths
 from ipaplatform.tasks import tasks
 from ipalib import api, errors, x509
-from ipalib.constants import IPA_CA_NICKNAME, RENEWAL_CA_NAME
+from ipalib.constants import IPA_CA_NICKNAME, RENEWAL_CA_NAME, GC_SERVER_ID
 from ipalib.util import check_client_configuration
 
 logger = logging.getLogger(__name__)
@@ -173,6 +173,15 @@ def update_server(certs):
     update_db(paths.ETC_DIRSRV_SLAPD_INSTANCE_TEMPLATE % instance, certs)
     if services.knownservices.dirsrv.is_running():
         services.knownservices.dirsrv.restart(instance)
+
+    # pylint: disable=import-error,ipa-forbidden-import
+    from ipaserver.install import gcinstance
+    # pylint: enable=import-error,ipa-forbidden-import
+    if gcinstance.is_gc_configured():
+        update_db(paths.ETC_DIRSRV_SLAPD_INSTANCE_TEMPLATE % GC_SERVER_ID,
+                  certs)
+        if services.knownservices.globalcatalog.is_running():
+            services.knownservices.globalcatalog.restart(GC_SERVER_ID)
 
     criteria = {
         'cert-database': paths.PKI_TOMCAT_ALIAS_DIR,

--- a/ipaserver/install/ipa_server_certinstall.py
+++ b/ipaserver/install/ipa_server_certinstall.py
@@ -24,6 +24,7 @@ import os.path
 import tempfile
 import optparse  # pylint: disable=deprecated-module
 
+from ipalib import constants
 from ipalib import x509
 from ipalib.install import certmonger
 from ipaplatform.paths import paths
@@ -59,6 +60,10 @@ class ServerCertInstall(admintool.AdminTool):
             dest="kdc", action="store_true", default=False,
             help="install PKINIT certificate for the KDC")
         parser.add_option(
+            "-g", "--gcsrv",
+            dest="gcsrv", action="store_true", default=False,
+            help="install certificate for the globalcatalog")
+        parser.add_option(
             "--pin",
             dest="pin", metavar="PIN", sensitive=True,
             help="The password of the PKCS#12 file")
@@ -80,9 +85,10 @@ class ServerCertInstall(admintool.AdminTool):
 
         installutils.check_server_configuration()
 
-        if not any((self.options.dirsrv, self.options.http, self.options.kdc)):
+        if not any((self.options.dirsrv, self.options.http, self.options.kdc,
+                    self.options.gcsrv)):
             self.option_parser.error(
-                "you must specify dirsrv, http and/or kdc")
+                "you must specify dirsrv, http, gcsrv and/or kdc")
 
         if not self.args:
             self.option_parser.error("you must provide certificate filename")
@@ -119,6 +125,9 @@ class ServerCertInstall(admintool.AdminTool):
         if self.options.kdc:
             self.replace_kdc_cert()
 
+        if self.options.gcsrv:
+            self.install_gcsrv_cert()
+
         print(
             "Please restart ipa services after installing certificate "
             "(ipactl restart)")
@@ -138,6 +147,29 @@ class ServerCertInstall(admintool.AdminTool):
         server_cert = self.import_cert(dirname, self.options.pin,
                                        old_cert, 'ldap/%s' % api.env.host,
                                        'restart_dirsrv %s' % serverid)
+
+        entry['nssslpersonalityssl'] = [server_cert]
+        try:
+            conn.update_entry(entry)
+        except errors.EmptyModlist:
+            pass
+
+    def install_gcsrv_cert(self):
+        serverid = constants.GC_SERVER_ID
+        dirname = dsinstance.config_dirname(serverid)
+        ldap_uri = ipaldap.get_ldap_uri(realm=constants.GC_REALM_NAME,
+                                        protocol='ldapi')
+        conn = ipaldap.LDAPClient(ldap_uri)
+        conn.external_bind()
+        entry = conn.get_entry(DN(('cn', 'RSA'), ('cn', 'encryption'),
+                                  ('cn', 'config')),
+                               ['nssslpersonalityssl'])
+        old_cert = entry.single_value['nssslpersonalityssl']
+
+        server_cert = self.import_cert(
+            dirname, self.options.pin, old_cert,
+            'ldap/%s/%s' % (api.env.host, api.env.domain),
+            'restart_dirsrv %s' % serverid)
 
         entry['nssslpersonalityssl'] = [server_cert]
         try:

--- a/ipaserver/install/server/install.py
+++ b/ipaserver/install/server/install.py
@@ -705,7 +705,7 @@ def install_check(installer):
 
     if options.setup_adtrust:
         adtrust.install_check(False, options, api)
-        gc.install_check(api,options)
+        gc.install_check(False,api,options)
 
     # installer needs to update hosts file when DNS subsystem will be
     # installed or custom addresses are used
@@ -967,7 +967,7 @@ def install(installer):
 
     if options.setup_adtrust:
         adtrust.install(False, options, fstore, api)
-        gc.install(api, fstore, options)
+        gc.install(False, api, fstore, options)
 
     # Set the admin user kerberos password
     ds.change_admin_password(admin_password)


### PR DESCRIPTION
### GC installer: fix install in CA-less env

When GC installer is provided with certificates for the
GC instance, it needs to use a different CA chain depending
on the way the installer is called:
if from ipa-server-install, then the CA is taken from the provided
--gc-cert-files
if from ipa-adtrust-install, then the CA is taken from /etc/ipa/ca.crt

Also fix the method adding the cert to the service entry:
for standard services, the service DN is
krbprincipalname=<principal>,cn=services,cn=accounts,<basedn>
    
The GC has a special principal name ldap/fqdn/domain@REALM but
is sharing the service entry with the standard LDAP service which has
principal name: ldap/fqdn@REALM.

### ipa-server-certinstall: replace global catalog cert

ipa-server-certinstall can also be used to replace the
Global Catalog certificate.
The option -g | --gcsrv is introduced for that usage.

The command ipa-certupdate is also modified to update the
global catalog NSS database.

