### PR TITLE
gcinstance: preconfigure service principal aliases for GC as expected…

### DIFF
--- a/ipaserver/install/gc.py
+++ b/ipaserver/install/gc.py
@@ -11,6 +11,7 @@ from ipapython.install.common import Installable, Interactive
 from ipapython.install.core import group, knob, Composite
 from ipapython.install import typing
 from ipaserver.install import ca, dsinstance, gcinstance
+from ipaserver.install import adtrust, adtrustinstance
 from ipaserver.install import installutils
 from ipapython import ipautil
 
@@ -116,6 +117,8 @@ def install(standalone, api, fstore, installer):
         gc = gcinstance.GCInstance(fstore=fstore, domainlevel=domainlevel)
         installer._gc = gc
         gc.create_instance(api.env.realm, api.env.host, api.env.domain,
+                           adtrustinstance.make_netbios_name(api.env.host),
+                           adtrust.netbios_name,
                            gc_password, gc_pkcs12_info,
                            subject_base=subject_base,
                            ca_subject=ca_subject)
@@ -123,6 +126,8 @@ def install(standalone, api, fstore, installer):
         gc = gcinstance.GCInstance(fstore=fstore, domainlevel=domainlevel)
         installer._gc = gc
         gc.create_instance(api.env.realm, api.env.host, api.env.domain,
+                           adtrustinstance.make_netbios_name(api.env.host),
+                           adtrust.netbios_name,
                            gc_password,
                            subject_base=subject_base,
                            ca_subject=ca_subject)


### PR DESCRIPTION
… by MS-DRSR

AD DCs expect RPC service principal name to exist for the machine
account of the domain controller they talk to. Since in FreeIPA case
Kerberos principals for host/ and cifs/ are separate, we need to add
RPC/... alias to cifs/... principal.

There are other service principal names for GC that are expected to
exist according to MS-DRSR 2.2.3 and 2.2.4 sections. Refactor GC
instance code to include all of them.

Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>