### PR TITLE
GC: workaround for invalid syncrepl cookie

### DIFF
--- a/ipaserver/globalcatalog/gcsyncer.py
+++ b/ipaserver/globalcatalog/gcsyncer.py
@@ -4,7 +4,6 @@
 
 from __future__ import absolute_import
 
-import json
 import ldap
 import logging
 from io import StringIO
@@ -353,7 +352,6 @@ class GCSyncer(ReconnectLDAPObject, SyncreplConsumer):
     def user_del(self, uuid, entry_dn, oldattrs):
         """Remove an existing user from the Global Catalog."""
         logger.debug("user_del %s", entry_dn)
-        dn = DN(entry_dn)
 
         # The corresponding GC entry must also be deleted but its GC-side DN
         # must be evaluated first by using the cn value.
@@ -369,8 +367,6 @@ class GCSyncer(ReconnectLDAPObject, SyncreplConsumer):
     def user_mod(self, uuid, entry_dn, newattrs, oldattrs):
         """Modify an existing user in the Global Catalog."""
         logger.debug("user_sync %s", entry_dn)
-        olddn = DN(oldattrs['dn'])
-        newdn = DN(entry_dn)
 
         # As we are only monitoring leaf entries, it is easier
         # to simply del the previous one and create a new one instead
@@ -420,7 +416,6 @@ class GCSyncer(ReconnectLDAPObject, SyncreplConsumer):
     def group_del(self, uuid, entry_dn, oldattrs):
         """Remove an existing group from the Global Catalog."""
         logger.debug("group_del %s", entry_dn)
-        dn = DN(entry_dn)
 
         # The corresponding GC entry must also be deleted but its GC-side DN
         # must be evaluated first by using the cn value.
@@ -436,8 +431,6 @@ class GCSyncer(ReconnectLDAPObject, SyncreplConsumer):
     def group_mod(self, uuid, entry_dn, newattrs, oldattrs):
         """Modify an existing group in the Global Catalog."""
         logger.debug("group_sync %s", entry_dn)
-        olddn = DN(oldattrs['dn'])
-        newdn = DN(entry_dn)
 
         # As we are only monitoring leaf entries, it is easier
         # to simply del the previous one and create a new one instead

--- a/ipaserver/globalcatalog/gcsyncer.py
+++ b/ipaserver/globalcatalog/gcsyncer.py
@@ -188,7 +188,7 @@ class GCSyncer(ReconnectLDAPObject, SyncreplConsumer):
                 content = f.read()
             # if the content is an empty string, simply return None
             if content:
-                cookie = content
+                cookie = content.strip()
                 logger.debug("Read cookie %s", cookie)
         except FileNotFoundError:
             # It's ok if no cookie was saved, it may be the first run
@@ -242,6 +242,12 @@ class GCSyncer(ReconnectLDAPObject, SyncreplConsumer):
 
     def syncrepl_set_cookie(self, cookie):
         logger.debug('New cookie is: %s', cookie)
+        if cookie and cookie.endswith('#4294967295'):
+            # Workaround for syncrepl issue 51190
+            # https://pagure.io/389-ds-base/issue/51190
+            # Just ignore this cookie and keep the previous one
+            logger.debug("Ignoring cookie value")
+            return
         self.__data['cookie'] = cookie
 
     def syncrepl_entry(self, dn, attributes, uuid):


### PR DESCRIPTION
syncrepl may provide an invalid cookie because of
https://pagure.io/389-ds-base/issue/51190

The workaround is to ignore the cookie if it contains an invalid
change number ending with #4294967295