### PR TITLE
GC: speed up content sync

### DIFF
--- a/ipaserver/globalcatalog/gcsyncer.py
+++ b/ipaserver/globalcatalog/gcsyncer.py
@@ -344,6 +344,7 @@ class GCSyncer(ReconnectLDAPObject, SyncreplConsumer):
         except ValueError as e:
             logger.error("Failed to create GC entry based on %s (%s)",
                          entry_dn, e)
+            del self.__data['uuids'][uuid]
             return
         logger.debug("Adding user to the Global Catalog %s", ldif_add)
         parser = AddLDIF(ldif_add, self.gc_conn)
@@ -408,6 +409,7 @@ class GCSyncer(ReconnectLDAPObject, SyncreplConsumer):
         except ValueError as e:
             logger.error("Failed to create GC entry based on %s (%s)",
                          entry_dn, e)
+            del self.__data['uuids'][uuid]
             return
         logger.debug("Adding group to the Global Catalog %s", ldif_add)
         parser = AddLDIF(ldif_add, self.gc_conn)

--- a/ipaserver/globalcatalog/gcsyncer.py
+++ b/ipaserver/globalcatalog/gcsyncer.py
@@ -276,12 +276,16 @@ class GCSyncer(ReconnectLDAPObject, SyncreplConsumer):
         if uuid in self.__data['uuids']:
             change_type = 'modify'
             previous_attrs = self.__data['uuids'][uuid]
+            if attributes == previous_attrs.get('syncrepl_attrs'):
+                logger.debug("No interesting change for %s, dropping", dn)
+                return
         else:
             change_type = 'add'
         # Now we store our knowledge of the existence of this entry
         # (including the DN as an attribute for convenience)
         attrs['dn'] = dn
         attrs['cn'] = attributes['cn'][0].decode('utf-8')
+        attrs['syncrepl_attrs'] = attributes
         self.__data['uuids'][uuid] = attrs
         # Debugging
         logger.debug('Detected %s of entry: %s %s', change_type, dn, uuid)


### PR DESCRIPTION
### Global Catalog: speed up change handling

When syncrepl sends an update on an existing entry, it's
possible that the change is not related to any interesting
attribute (for instance modification of the "street" attr
of a user) from a GC point of view.

Store the previous data sent by syncrepl and compare with the
new data, in order to drop meaningless changes. This avoids
unnecessary calls to DEL+ADD with the same content.

### Global Catalog: fix logic when add fails

When an entry cannot be added in the Global Catalog
because it is missing a mandatory attribute (like
SID for instance), do not store its uuid in the
internal structure. This avoids calling DEL+ADD on
the next update and treats the entry as a new addition.