### PR TITLE
GC: Create ForeignSecurityPrincipals entries

### DIFF
--- a/ipaserver/globalcatalog/gcsyncer.py
+++ b/ipaserver/globalcatalog/gcsyncer.py
@@ -419,6 +419,16 @@ class GCSyncer(ReconnectLDAPObject, SyncreplConsumer):
         parser = AddLDIF(ldif_add, self.gc_conn)
         parser.parse()
 
+        # If the group contains external members, we also need to create a
+        # ForeignSecurityPrincipal for each one
+        for memberSid in newattrs.get('ipaexternalmember', []):
+            fsp_ldif = self.gc.create_ldif_foreignsecurityprincipal(
+                memberSid.decode('utf-8'))
+            logger.debug("Adding foreignSecurityPrincipal to the "
+                         "Global Catalog %s", fsp_ldif)
+            parser = AddLDIF(fsp_ldif, self.gc_conn)
+            parser.parse()
+
     def group_del(self, uuid, entry_dn, oldattrs):
         """Remove an existing group from the Global Catalog."""
         logger.debug("group_del %s", entry_dn)

--- a/ipaserver/globalcatalog/templates/gc_fsp_template.tmpl
+++ b/ipaserver/globalcatalog/templates/gc_fsp_template.tmpl
@@ -1,0 +1,10 @@
+dn: CN={{ sidstring }},CN=ForeignSecurityPrincipals,{{ suffix }}
+objectClass: top
+objectClass: ad-top
+objectclass: foreignSecurityPrincipal
+cn: {{ sidstring }}
+instanceType: 4
+name: {{ sidstring }}
+objectSid:: {{ sid }}
+objectCategory: CN=Foreign-Security-Principal,CN=Schema,CN=Configuration,{{ suffix }}
+ntsecuritydescriptor: D:(A;;RPWPCRCCDCLCLORCWOWDSDDTSW;;;DA)(A;;RPWPCRCCDCLCLORCWOWDSDDTSW;;;SY)(A;;RPWPCRCCDCLCLORCWOWDSDDTSW;;;AO)(A;;RPLCLORC;;;PS)(OA;;CR;ab721a53-1e2f-11d0-9819-00aa0040529b;;PS)(OA;;CR;ab721a54-1e2f-11d0-9819-00aa0040529b;;PS)(OA;;CR;ab721a56-1e2f-11d0-9819-00aa0040529b;;PS)(OA;;RPWP;77B5B886-944A-11d1-AEBD-0000F80367C1;;PS)(OA;;RPWP;E45795B2-9455-11d1-AEBD-0000F80367C1;;PS)(OA;;RPWP;E45795B3-9455-11d1-AEBD-0000F80367C1;;PS)(A;;RC;;;AU)(OA;;RP;59ba2f42-79a2-11d0-9020-00c04fc2d3cf;;AU)(OA;;RP;77B5B886-944A-11d1-AEBD-0000F80367C1;;AU)(OA;;RP;E45795B3-9455-11d1-AEBD-0000F80367C1;;AU)(OA;;RP;e48d0154-bcf8-11d1-8702-00c04fb96050;;AU)(OA;;CR;ab721a53-1e2f-11d0-9819-00aa0040529b;;WD)

--- a/ipaserver/globalcatalog/transfo.py
+++ b/ipaserver/globalcatalog/transfo.py
@@ -197,6 +197,7 @@ class GCTransformer:
         jinja_env = Environment(loader=loader)
         self.user_template = jinja_env.get_template('gc_user_template.tmpl')
         self.group_template = jinja_env.get_template('gc_group_template.tmpl')
+        self.fsp_template = jinja_env.get_template('gc_fsp_template.tmpl')
         self.api = api
         self.ldap_conn = conn
 
@@ -234,4 +235,16 @@ class GCTransformer:
             entry=entry, pkey=pkey, guid=guid,
             sid=sid, suffix=api.env.basedn, groupType=groupType,
             entryuuid=uuid)
+        return ldif_add
+
+    def create_ldif_foreignsecurityprincipal(self, sidstring):
+        """Creates a LDIF allowing to add a ForeignSecurityPrincipal entry
+
+        sidstring: the sid using a string format, for instance
+        S-1-5-21-704000768-2575068322-3001777647-1109
+        """
+        sid = transform_sid_value(sidstring)
+        ldif_add = self.fsp_template.render(
+            sidstring=sidstring, sid=sid,
+            suffix=api.env.basedn)
         return ldif_add


### PR DESCRIPTION
- add a template for ForeignSecurityPrincipals
- on group addition, extract the external members and for each one,
create an entry cn=<SID>,cn=ForeignSecurityPrincipals,<suffix>
in the Global Catalog.