### PR TITLE
GC: use consistent lowercase for cn=users container

### DIFF
--- a/install/gc/share/base/00-ad-bootstrap-template.ldif
+++ b/install/gc/share/base/00-ad-bootstrap-template.ldif
@@ -94,7 +94,7 @@ objectClass: account
 objectClass: top
 uid: read-only-principal
 
-dn: CN=ForeignSecurityPrincipals,$SUFFIX
+dn: cn=ForeignSecurityPrincipals,$SUFFIX
 changetype: add
 objectClass: top
 objectClass: ad-top

--- a/ipaserver/globalcatalog/templates/gc_fsp_template.tmpl
+++ b/ipaserver/globalcatalog/templates/gc_fsp_template.tmpl
@@ -1,4 +1,4 @@
-dn: CN={{ sidstring }},CN=ForeignSecurityPrincipals,{{ suffix }}
+dn: cn={{ sidstring }},cn=ForeignSecurityPrincipals,{{ suffix }}
 objectClass: top
 objectClass: ad-top
 objectclass: foreignSecurityPrincipal

--- a/ipaserver/globalcatalog/templates/gc_group_template.tmpl
+++ b/ipaserver/globalcatalog/templates/gc_group_template.tmpl
@@ -1,4 +1,4 @@
-dn: CN={{ pkey }},CN=Users,{{ suffix }}
+dn: cn={{ pkey }},cn=users,{{ suffix }}
 objectClass: top
 objectClass: ad-top
 objectClass: group

--- a/ipaserver/globalcatalog/templates/gc_user_template.tmpl
+++ b/ipaserver/globalcatalog/templates/gc_user_template.tmpl
@@ -1,7 +1,7 @@
 {% macro first_val(attr) -%}
     {{ entry[attr][0] }}
 {%- endmacro %}
-dn: CN={{ first_val('cn') }},CN=Users,{{ suffix }}
+dn: cn={{ first_val('cn') }},cn=users,{{ suffix }}
 objectClass: top
 objectClass: person
 objectClass: organizationalPerson

--- a/ipaserver/globalcatalog/transfo.py
+++ b/ipaserver/globalcatalog/transfo.py
@@ -85,10 +85,10 @@ def rename_dn(api, dn, conn):
         user = conn.get_entry(
             dn, ["cn"], time_limit=0, size_limit=-1)
         user_cn = user.single_value['cn']
-        return 'CN={},CN=Users,{}'.format(user_cn, api.env.basedn)
+        return 'cn={},cn=users,{}'.format(user_cn, api.env.basedn)
     if dn.find(groups_dn) == 1:
         # The member value is right below the group container
-        return '{},CN=Users,{}'.format(dn[0], api.env.basedn)
+        return '{},cn=users,{}'.format(dn[0], api.env.basedn)
     # Unable to find a corresponding member
     raise ValueError
 
@@ -188,7 +188,7 @@ def get_dn_from_cn(api, cn):
     CN=..,CN=Users,$base
     It's easy to build the GC DN from a cn value.
     """
-    return DN("CN={},CN=Users,{}".format(cn, api.env.basedn))
+    return DN("cn={},cn=users,{}".format(cn, api.env.basedn))
 
 
 class GCTransformer:


### PR DESCRIPTION
The GC sometimes uses CN=Users or cn=users, see for instance:
dn: CN=idmgroup3,cn=users,dc=testrelm,dc=test
memberOf: cn=ipausers,cn=users,dc=testrelm,dc=test
member: CN=First User,CN=Users,dc=testrelm,dc=test

Although there is no harm because the attribute type is case-insensitive,
it is nicer to use a consistent case. Fix the templates and the
transformation code to always use lowercase.

Fixes: https://github.com/abbra/freeipa/issues/59