### PR TITLE
GC: Fix systemd link for global catalog service

### DIFF
--- a/ipaplatform/redhat/services.py
+++ b/ipaplatform/redhat/services.py
@@ -74,7 +74,7 @@ redhat_system_units['ods_enforcerd'] = redhat_system_units['ods-enforcerd']
 redhat_system_units['ods-signerd'] = 'ods-signerd.service'
 redhat_system_units['ods_signerd'] = redhat_system_units['ods-signerd']
 redhat_system_units['gssproxy'] = 'gssproxy.service'
-redhat_system_units['globalcatalog'] = 'dirsrv@GLOBAL-CATALOG.service'
+redhat_system_units['globalcatalog'] = 'dirsrv@.service'
 redhat_system_units['ipa-gcsyncd'] = 'ipa-gcsyncd.service'
 
 


### PR DESCRIPTION
When installing the Global Catalog, a symlink is created in
/etc/systemd/system/dirsrv.target.wants/ for GC:
dirsrv@GLOBAL-CATALOG.service -> /usr/lib/systemd/system/dirsrv@GLOBAL-CATALOG.service

But the file /usr/lib/systemd/system/dirsrv@GLOBAL-CATALOG.service
does not exist. The correct link should be pointing to
/usr/lib/systemd/system/dirsrv@.service

This happens because the known service for Global Catalog defines
the systemd service as dirsrv@GLOBAL-CATALOG.service instead of
dirsrv@.service

Fixes: https://github.com/abbra/freeipa/issues/43