### PR TITLE
idp :: kdb: add idp to userauth table

### DIFF
--- a/daemons/ipa-kdb/ipa_kdb.c
+++ b/daemons/ipa-kdb/ipa_kdb.c
@@ -199,6 +199,7 @@ static const struct {
     { "otp", IPADB_USER_AUTH_OTP },
     { "pkinit", IPADB_USER_AUTH_PKINIT },
     { "hardened", IPADB_USER_AUTH_HARDENED },
+    { "idp", IPADB_USER_AUTH_IDP },
     { }
 };
 


### PR DESCRIPTION
This is needed to set the correct auth type to the principal.