### PR TITLE
Proposed changes for ARM 64 machines and macOS.

### DIFF
--- a/doc/workshop/lab/containerfile-fedora
+++ b/doc/workshop/lab/containerfile-fedora
@@ -1,4 +1,8 @@
-FROM registry.fedoraproject.org/fedora-toolbox:41
+FROM registry.fedoraproject.org/fedora-toolbox:41 as amd64
+FROM registry.fedoraproject.org/fedora-toolbox:40-aarch64 as arm64
+
+FROM $TARGETARCH as workshopimage
+
 MAINTAINER [FreeIPA Developers freeipa-devel@lists.fedorahosted.org]
 ENV container=docker LANG=en_US.utf8 LANGUAGE=en_US.utf8 LC_ALL=en_US.utf8
 

--- a/doc/workshop/lab/workshop.yaml
+++ b/doc/workshop/lab/workshop.yaml
@@ -24,22 +24,17 @@ ipa_deployments:
           memory: 2gb
           vars:
             ipaserver_netbios_name: S1
-            ipaserver_idstart: 51000
-            ipaserver_idmax: 52000
-            ipaserver_rid_base: 53000
-            ipaserver_secondary_rid_base: 55000
+            ipaserver_idstart: 61000
+            ipaserver_idmax: 62000
+            ipaserver_rid_base: 63000
+            ipaserver_secondary_rid_base: 65000
         - name: replica
           capabilities:
             - DNS
             - AD
           memory: 2gb
           vars:
-            ipaserver_netbios_name: S1
-            ipaserver_idstart: 61000
-            ipaserver_idmax: 62000
-            ipaserver_rid_base: 63000
-            ipaserver_secondary_rid_base: 70000
-        - name: replica
+            ipareplica_netbios_name: S1
       clients:
         - name: client
           memory: 1gb

--- a/doc/workshop/workshop.rst
+++ b/doc/workshop/workshop.rst
@@ -120,18 +120,28 @@ packages::
 Also ensure you have the latest versions of ``selinux-policy`` and
 ``selinux-policy-targeted``.
 
-Mac OS X
-^^^^^^^^
+macOS
+^^^^^^
 
-Install Vagrant for Mac OS X from
-https://www.vagrantup.com/downloads.html.
+Install ``podman`` and ``podman-compose`` using any packagem manager that
+provides both tools, for example `Homebrew <brew.sh>`.
 
-Install VirtualBox 6.1 for **OS X hosts** from
-https://www.virtualbox.org/wiki/Downloads.
+If using brew you can install the tools with::
 
-Install Git from https://git-scm.com/download/mac or via your
-preferred package manager.
+  $ brew install podman podman-compose
 
+As the containers run within a virtual machine on macOS, you will need to
+initialize the virtual machine with enough memory no run the cluster, plus
+some spare space for the VM operating system.
+
+As the default machine is created with only 2Gb of memory, create a custom
+machine with, at least, 6Gb of memory::
+
+  $ podman machine init --memory 6144
+  $ podman machine start
+
+This may require using updating Rosetta no macOS, just follow the system
+instructions.
 
 Debian / Ubuntu
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
Tested these changes against Raspberry Pi 4 and macOS Sequoia on Apple Silicon (M1).

* Fixed idstart/idrange indexes so that they work on Fedora 40/41 containers
* Fixed container image creation so that ARM 64 hosts can be used
* Modified macOS instructions to use containers instead of VirtualBox.